### PR TITLE
Add date headers

### DIFF
--- a/jsonld-addon-filters/src/main/java/org/dataconservancy/fcrepo/jsonld/compact/CompactingOutputStream.java
+++ b/jsonld-addon-filters/src/main/java/org/dataconservancy/fcrepo/jsonld/compact/CompactingOutputStream.java
@@ -43,11 +43,11 @@ public class CompactingOutputStream extends FilterOutputStream {
 
     final Compactor compactor;
 
-    private boolean compactionEnabled = false;
+    boolean compactionEnabled = false;
 
     private final URL context;
 
-    private final ByteArrayOutputStream captured = new ByteArrayOutputStream();
+    final ByteArrayOutputStream captured = new ByteArrayOutputStream();
 
     /**
      * Wrap the given OutputStream with the given compactor and context URL.

--- a/jsonld-addon-filters/src/main/java/org/dataconservancy/fcrepo/jsonld/compact/CompactionFilter.java
+++ b/jsonld-addon-filters/src/main/java/org/dataconservancy/fcrepo/jsonld/compact/CompactionFilter.java
@@ -42,10 +42,11 @@ import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
 import org.dataconservancy.fcrepo.jsonld.LogUtil;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.jsonldjava.core.JsonLdOptions;
 
 /**
@@ -102,7 +103,7 @@ public class CompactionFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
-            ServletException {
+    ServletException {
 
         final HttpServletRequest req = (HttpServletRequest) request;
         final HttpServletResponse resp = (HttpServletResponse) response;
@@ -115,6 +116,13 @@ public class CompactionFilter implements Filter {
                     compactor,
                     defaultContext);
             chain.doFilter(new CompactionRequestWrapper(req), compactionWrapper);
+
+            if (compactionWrapper.compactingOutputStream.compactionEnabled) {
+                LOG.warn(new String(compactionWrapper.compactingOutputStream.captured.toByteArray()));
+                ObjectNode rawJson = new ObjectMapper()
+                        .readValue(compactionWrapper.compactingOutputStream.captured.toByteArray(), ObjectNode.class);
+            }
+
             compactionWrapper.getOutputStream().close();
         } catch (final Exception e) {
             LOG.warn("Internal error", e);

--- a/jsonld-addon-integration/pom.xml
+++ b/jsonld-addon-integration/pom.xml
@@ -87,7 +87,7 @@
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
         <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.6.7</version>
+        <version>1.7.16</version>
         <configuration>
           <!-- Container configuration -->
           <container>
@@ -160,7 +160,6 @@
   </build>
 
   <dependencies>
-
     <dependency>
       <groupId>org.dataconservancy.fcrepo</groupId>
       <artifactId>jsonld-addon-filters</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven-javadoc-pugin.version}</version>
+	  <configuration>
+            <source>8</source>
+          </configuration>
           <executions>
             <execution>
               <id>attach-javadocs</id>


### PR DESCRIPTION
Exposes date headers, but has no tests.   Adds a few tweaks so that it builds in 2021 against openjdk8.

The crux of the implementation is in [CompactionFilter](https://github.com/DataConservancy/fcrepo-jsonld/blob/add-date-headers/jsonld-addon-filters/src/main/java/org/dataconservancy/fcrepo/jsonld/compact/CompactionFilter.java#L123-L139).  Essentially, it just parses the raw JSONLD from Fedora, extracts dates, and adds headers to the response.

The main consequence of this approach is that date headers are _only_ added when the request is a `GET` request for json-ld, _and_ the result is in compact form.  This means only PASS services that request jsonld will see these headers.  These headers would not appear in, say, requests for `test/turtle`, and would not appear in `HEAD`.

## To test/debug

`mvn clean install`.

To run a Fedora with the newly built (and post-test data still in it), go to `fcrepo-jsonld/jsonld-addon-integration` and do `mvn cargo:run -Pstandard`.  This will run a Fedora on port 8080, with the test "farm" context enabled.  If run immediately after tests, it'll still have data in it.   You can look at the headers via something like

     curl -v -H "Accept: application/ld+json"  http://localhost:8080/fcrepo/rest/..............

For example:
<pre>
$ curl -v -H "Accept: application/ld+json" http://localhost:8080/fcrepo/rest/02/4a/76/29/024a7629-f3cb-4432-9076-e5c06635c582
*   Trying ::1:8080...
* Connected to localhost (::1) port 8080 (#0)
> GET /fcrepo/rest/02/4a/76/29/024a7629-f3cb-4432-9076-e5c06635c582 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.74.0
> Accept: application/ld+json
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200
< ETag: W/"13196dd70ec40f5d4a69da85ef2028e9f1d19a94"
< Last-Modified: Thu, 13 May 2021 06:07:49 GMT
< Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
< Link: <http://www.w3.org/ns/ldp#Container>;rel="type"
< Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
< Accept-Patch: application/sparql-update, application/merge-patch+json
< Accept-Post: text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
< Allow: MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
< Preference-Applied: return=representation
< Vary: Prefer
< Vary: Accept, Range, Accept-Encoding, Accept-Language
< X-CREATED: 2021-05-13T06:07:49.578Z
< X-MODIFIED: 2021-05-13T06:07:49.578Z
< Content-Type: application/ld+json
< Transfer-Encoding: chunked
< Date: Thu, 13 May 2021 06:11:02 GMT
<
{
  "@id" : "http://localhost:8080/fcrepo/rest/02/4a/76/29/024a7629-f3cb-4432-9076-e5c06635c582",
  "@type" : "Cow",
  "birthDate" : "1980-12-01T00:00:00.000Z",
  "healthy" : false,
  "milkVolume" : 30.5,
  "name" : "yoda",
  "weight" : 124,
  "@context" : "http://example.org/farm"
}
</pre>

Needed by OA-PASS/pass-indexer#27
Part of implementation for OA-PASS/general-issues#150