### PR TITLE
Fix inbound reference handling

### DIFF
--- a/jsonld-addon-filters/src/main/java/org/dataconservancy/fcrepo/jsonld/compact/CompactionFilter.java
+++ b/jsonld-addon-filters/src/main/java/org/dataconservancy/fcrepo/jsonld/compact/CompactionFilter.java
@@ -195,8 +195,9 @@ public class CompactionFilter implements Filter {
                 }
                 return orig;
             } else if (name.equalsIgnoreCase("prefer")) {
-                // Ignore requests to modify representation since this filter overriding them.
-                if (orig != null && orig.startsWith("return=representation;")) {
+                // Ignore requests to modify representation since this filter overriding them unless it is a request
+                // for inbound references. The PASS Java client has a getIncoming method which relies on it.
+                if (orig != null && orig.startsWith("return=representation;") && !orig.contains("http://fedora.info/definitions/v4/repository#InboundReferences")) {
                     final String prefers = "return=representation";
                     LOG.debug("Transforming original prefer header {} into  {}", orig, prefers);
                     return prefers;

--- a/jsonld-addon-integration/src/test/java/org/dataconservancy/fcrepo/jsonld/integration/CompactionIT.java
+++ b/jsonld-addon-integration/src/test/java/org/dataconservancy/fcrepo/jsonld/integration/CompactionIT.java
@@ -198,8 +198,7 @@ public class CompactionIT implements FcrepoIT {
             assertTrue(ids.contains(childJsonldResource1.toString()));
             assertTrue(ids.contains(jsonldResource.toString()));
 
-            assertNotNull(response.getHeaderValue("X-CREATED"));
-            assertNotNull(response.getHeaderValue("X-MODIFIED"));
+            // In this case no support for X-CREATED and X-MODIFIED
         }
     }
 

--- a/jsonld-addon-integration/src/test/java/org/dataconservancy/fcrepo/jsonld/integration/CompactionIT.java
+++ b/jsonld-addon-integration/src/test/java/org/dataconservancy/fcrepo/jsonld/integration/CompactionIT.java
@@ -18,13 +18,19 @@ package org.dataconservancy.fcrepo.jsonld.integration;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.dataconservancy.fcrepo.jsonld.test.JsonldTestUtil.assertCompact;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
@@ -37,6 +43,8 @@ import org.apache.http.util.EntityUtils;
 import org.fcrepo.client.FcrepoClient;
 import org.fcrepo.client.FcrepoClient.FcrepoClientBuilder;
 import org.fcrepo.client.FcrepoResponse;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.Test;
 
 /**
@@ -120,6 +128,75 @@ public class CompactionIT implements FcrepoIT {
 
             final String body = IOUtils.toString(response.getBody(), UTF_8);
             assertCompact(body);
+
+            assertNotNull(response.getHeaderValue("X-CREATED"));
+            assertNotNull(response.getHeaderValue("X-MODIFIED"));
+        }
+    }
+
+    @Test
+    // The pass-java-client has a getIncoming method which expects a @graph returned
+    // when inbound references are specified in the Prefer header.
+    public void testInboundPrefer() throws Exception {
+        final FcrepoClient client = new FcrepoClientBuilder().throwExceptionOnFailure().build();
+
+        final URI childJsonldResource1 = attempt(60, () -> {
+            try (FcrepoResponse response = client
+                .post(URI.create(fcrepoBaseURI))
+                .body(this.getClass().getResourceAsStream("/compact-uri.json"), "application/ld+json")
+                .perform()) {
+                return response.getLocation();
+            }
+        });
+
+        final URI childJsonldResource2 = attempt(60, () -> {
+            try (FcrepoResponse response = client
+                .post(URI.create(fcrepoBaseURI))
+                .body(this.getClass().getResourceAsStream("/compact-uri.json"), "application/ld+json")
+                .perform()) {
+                return response.getLocation();
+            }
+        });
+
+        final URI jsonldResource = attempt(60, () -> {
+            String json = "{\n"
+                    + "  \"@context\": \"http://example.org/farm\",\n"
+                    + "  \"@id\": \"\",\n"
+                    + "  \"@type\": \"Cow\",\n"
+                    + "  \"calves\": [\"" + childJsonldResource1 + "\", \"" + childJsonldResource2 + "\"],\n"
+                    + "  \"healthy\": true,\n"
+                    + "  \"name\": \"bob\",\n"
+                    + "  \"weight\": 10000\n"
+                    + "}";
+
+            try (FcrepoResponse response = client
+                .post(URI.create(fcrepoBaseURI))
+                .body(new ByteArrayInputStream(json.getBytes(Charset.forName("UTF-8"))), "application/ld+json")
+                .perform()) {
+                return response.getLocation();
+            }
+        });
+
+        try (FcrepoResponse response = client
+            .get(childJsonldResource1)
+            .accept("application/ld+json")
+            .preferRepresentation(Arrays.asList(URI.create("http://fedora.info/definitions/v4/repository#InboundReferences")), Arrays.asList())
+            .perform()) {
+
+            final String body = IOUtils.toString(response.getBody(), UTF_8);
+
+            JSONObject o = new JSONObject(body);
+            assertTrue(o.has("@graph"));
+            JSONArray grapharr = o.getJSONArray("@graph");
+            assertEquals(2, grapharr.length());
+            JSONObject o1 = grapharr.getJSONObject(0);
+            JSONObject o2 = grapharr.getJSONObject(1);
+            Set<String> ids = new HashSet<>();
+            ids.add(o1.getString("@id"));
+            ids.add(o2.getString("@id"));
+
+            assertTrue(ids.contains(childJsonldResource1.toString()));
+            assertTrue(ids.contains(jsonldResource.toString()));
 
             assertNotNull(response.getHeaderValue("X-CREATED"));
             assertNotNull(response.getHeaderValue("X-MODIFIED"));

--- a/jsonld-addon-integration/src/test/resources/context.jsonld
+++ b/jsonld-addon-integration/src/test/resources/context.jsonld
@@ -11,6 +11,6 @@
     "milkVolume": {"@id": "farm:milkVolume"},    
     "weight": {"@id": "farm:weight"},
     "barn": {"@id": "farm:barn", "@type": "@id"},    
-    "calves": {"@id": "farm:calves", "@container": "@set"}
+    "calves": {"@id": "farm:calves", "@container": "@set", "@type": "@id"}
   }
 }

--- a/jsonld-addon-tests/src/main/resources/context-aliased.jsonld
+++ b/jsonld-addon-tests/src/main/resources/context-aliased.jsonld
@@ -14,6 +14,6 @@
     "milkVolume": {"@id": "farm:milkVolume"},    
     "weight": {"@id": "farm:weight"},
     "barn": {"@id": "farm:barn", "@type": "@id"},    
-    "calves": {"@id": "farm:calves", "@container": "@set"}
+    "calves": {"@id": "farm:calves", "@container": "@set", "@type": "@id"}
   }
 }

--- a/jsonld-addon-tests/src/main/resources/context.jsonld
+++ b/jsonld-addon-tests/src/main/resources/context.jsonld
@@ -11,6 +11,6 @@
     "milkVolume": {"@id": "farm:milkVolume"},    
     "weight": {"@id": "farm:weight"},
     "barn": {"@id": "farm:barn", "@type": "@id"},    
-    "calves": {"@id": "farm:calves", "@container": "@set"}
+    "calves": {"@id": "farm:calves", "@container": "@set", "@type": "@id"}
   }
 }


### PR DESCRIPTION
The PASS Java client uses the ability of fedora to return a graph of inbound references when the correct Prefer header is set. The handling had been inadvertently broken by modifying the prefer header handling of the compaction filter. This pr makes sure Fedora sees the inbound references request and adds a corresponding integration test.